### PR TITLE
docs: rename contribute as contributing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,5 +61,5 @@ rg-cli --csv ./a.csv --csv ./b.csv --csv ./c.csv --yaml ./report_generator/data/
 
 Follow the prompt instruction and you will get jpg images. So far it is well tested with the data of year 2017.
 
-## How to contribute
-Please see the [Contribute](contribute.md) for further details.
+## Contributing
+Please see the [Contributing](contributing.md) for further details.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,4 @@
-## How to contribute
+## Contributing
 
 ### Step 1. Fork this repository to your GitHub
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: PyCon TW post-event report generator (rg-cli)
 nav:
   - Home: README.md
-  - Contribute: contribute.md
+  - Contributing: contributing.md
 theme:
   name: 'material'
 repo_url: https://github.com/pycontw/pycontw-postevent-report-generator


### PR DESCRIPTION
GitHub will add a link to the file with docs/contributing as a
reference when creating issue